### PR TITLE
Remove useEffects debug and print human-readable states.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -115,12 +115,11 @@ const VideoPlayer = (props) => {
     };
     // https://usehooks.com/useEventListener/
     useEffect(() => {
-        const { videoProps, debug } = props;
+        const { videoProps } = props;
         if (videoProps.source === null) {
             console.error('`Source` is a required property');
             throw new Error('`Source` is required');
         }
-        debug && console.info(`User is ${isConnected ? 'on' : 'off'}line`);
         setAudio();
     });
     // Handle events during playback
@@ -128,7 +127,7 @@ const VideoPlayer = (props) => {
         if (playbackState !== newPlaybackState) {
             const { debug } = props;
             debug &&
-                console.info('[playback]', playbackState, ' -> ', newPlaybackState, ' [seek] ', seekState, ' [shouldPlay] ', shouldPlay);
+                console.info('[playback]', PlaybackStates[playbackState], ' -> ', PlaybackStates[newPlaybackState], ' [seek] ', SeekStates[seekState], ' [shouldPlay] ', shouldPlay);
             setPlaybackState(newPlaybackState);
             setLastPlaybackStateUpdate(Date.now());
         }
@@ -136,7 +135,7 @@ const VideoPlayer = (props) => {
     const updateSeekState = (newSeekState) => {
         const { debug } = props;
         debug &&
-            console.info('[seek]', seekState, ' -> ', newSeekState, ' [playback] ', playbackState, ' [shouldPlay] ', shouldPlay);
+            console.info('[seek]', SeekStates[seekState], ' -> ', SeekStates[newSeekState], ' [playback] ', PlaybackStates[playbackState], ' [shouldPlay] ', shouldPlay);
         setSeekState(newSeekState);
         // Don't keep the controls timer running when the state is seeking
         if (newSeekState === SeekStates.Seeking) {

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -203,14 +203,13 @@ const VideoPlayer = (props: Props) => {
 
   // https://usehooks.com/useEventListener/
   useEffect(() => {
-    const { videoProps, debug } = props
+    const { videoProps } = props
 
     if (videoProps.source === null) {
       console.error('`Source` is a required property')
       throw new Error('`Source` is required')
     }
 
-    debug && console.info(`User is ${isConnected ? 'on' : 'off'}line`)
     setAudio()
   })
 
@@ -221,11 +220,11 @@ const VideoPlayer = (props: Props) => {
       debug &&
         console.info(
           '[playback]',
-          playbackState,
+          PlaybackStates[playbackState],
           ' -> ',
-          newPlaybackState,
+          PlaybackStates[newPlaybackState],
           ' [seek] ',
-          seekState,
+          SeekStates[seekState],
           ' [shouldPlay] ',
           shouldPlay
         )
@@ -240,11 +239,11 @@ const VideoPlayer = (props: Props) => {
     debug &&
       console.info(
         '[seek]',
-        seekState,
+        SeekStates[seekState],
         ' -> ',
-        newSeekState,
+        SeekStates[newSeekState],
         ' [playback] ',
-        playbackState,
+        PlaybackStates[playbackState],
         ' [shouldPlay] ',
         shouldPlay
       )


### PR DESCRIPTION
The debug print in useEffects pollutes debug output with
repetitive output which is not needed anyway because a change in
connection state will end up calling updatePlaybackState which
has its own debug print.