### PR TITLE
fix: prevent accidental pressing of buttons in overlay header when the overlay is not visible

### DIFF
--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -304,7 +304,8 @@ const VideoPlayer = (tempProps: Props) => {
       </TouchableWithoutFeedback>
 
       <Animated.View
-        style={[
+          pointerEvents={controlsState === ControlStates.Visible ? 'auto' : 'none'}
+          style={[
           styles.bottomInfoWrapper,
           {
             opacity: controlsOpacity,

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -243,6 +243,7 @@ const VideoPlayer = (tempProps: Props) => {
       />
 
       <Animated.View
+        pointerEvents={controlsState === ControlStates.Visible ? 'auto' : 'none'}
         style={[
           styles.topInfoWrapper,
           {


### PR DESCRIPTION
I am using the header to contain the playback speed controls.
As of now, the controls are clicked even if the overlay is not visible, with no perceivable feedback apart from the speed change (the overlay does not show either, since the press event is captured by the button).

I applied the fix using the same approach already used for the controls section of the player.

Closes #725