### PR TITLE
Use fullscreen icons passed in props as an alternative to package-defined icons

### DIFF
--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -378,10 +378,10 @@ const VideoPlayer = (tempProps: Props) => {
             }
           >
             <View>
-              {props.icon.fullscreen}
-              {props.icon.exitFullscreen}
-              {((!props.icon.fullscreen && props.fullscreen.inFullscreen) ||
-                (!props.icon.exitFullscreen && !props.fullscreen.inFullscreen)) && (
+              {!props.fullscreen.inFullscreen && props.icon.fullscreen}
+              {props.fullscreen.inFullscreen && props.icon.exitFullscreen}
+              {((!props.icon.fullscreen && !props.fullscreen.inFullscreen) ||
+                (!props.icon.exitFullscreen && props.fullscreen.inFullscreen)) && (
                 <MaterialIcons
                   name={props.fullscreen.inFullscreen ? 'fullscreen-exit' : 'fullscreen'}
                   style={props.icon.style}


### PR DESCRIPTION
Closes #726 