### PR TITLE
Added controlsStyle props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/**/*
+.idea

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For compatibility information, scroll down to <a href='#compatibility'>Compatibi
 If you are updating from version 1.x to 2.x, there are some breaking changes in the API. Please visit [Migration guide to version 2](https://github.com/ihmpavel/expo-video-player/blob/master/migration-1x-to-2x.md) to make your transition as easy as possible. In version 2.x [@react-native-community/netinfo](https://github.com/react-native-netinfo/react-native-netinfo) has been removed.
 
 ## Installation
-- Install Video Player component typing into terminal `yarn add expo-video-player` _or_ `npm install expo-video-player`
+- Install Video Player component typing into terminal `yarn add clwy-expo-video-player` _or_ `npm install clwy-expo-video-player`
 - You also need `expo-av` and `@react-native-community/slider`. Install them with `expo-cli` (`expo install expo-av @react-native-community/slider`)
 
 ## Usage
@@ -18,7 +18,7 @@ The showcase of some of the possibilities you can create is in the folder [examp
 Minimal code to make `VideoPlayer` working
 ```
 import { ResizeMode } from 'expo-av'
-import VideoPlayer from 'expo-video-player'
+import VideoPlayer from 'clwy-expo-video-player'
 
 <VideoPlayer
   videoProps={{
@@ -42,6 +42,7 @@ For default prop values, please visit [/lib/props.tsx](https://github.com/ihmpav
 | **playbackCallback** | (status: AVPlaybackStatus) => void | Function which is fired every time `onPlaybackStatusUpdate` occurs |
 | **defaultControlsVisible** | `boolean` | Show controls on darker overlay when video starts playing. Default is `false` |
 | **timeVisible** | `boolean` | Show current time and final length in the bottom. Default is `true` |
+| **controlsStyle** | `ControlsStyle` | Object containing `Controls` styling |
 | **textStyle** | `TextStyle` | Object containing `<Text />` styling |
 | **slider** | `{ visible?: boolean } & SliderProps` | Object containing any of [@react-native-community/slider](https://github.com/callstack/react-native-slider) props. Your styling may break default layout. Also hide slider by providing `visible: false` prop. You are unable to overwrite `ref`, `value`, `onSlidingStart` and `onSlidingComplete` |
 | **activityIndicator** | `ActivityIndicatorProps` | Any values from [ActivityIndicator](https://reactnative.dev/docs/activityindicator) |

--- a/dist/index.js
+++ b/dist/index.js
@@ -219,6 +219,7 @@ const VideoPlayer = (tempProps) => {
             {
                 opacity: controlsOpacity,
             },
+            props.controlsStyle
         ]}>
         {props.timeVisible && (<Text style={[props.textStyle, styles.timeLeft]}>
             {getMinutesSecondsFromMilliseconds(playbackInstanceInfo.position)}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "expo-video-player",
-    "version": "2.2.0",
+    "name": "clwy-expo-video-player",
+    "version": "2.2.1",
     "private": false,
     "description": "Customizable Video Player controls for Expo",
     "keywords": [
@@ -13,8 +13,8 @@
         "videoplayer",
         "expo-videoplayer"
     ],
-    "homepage": "https://github.com/ihmpavel/expo-video-player",
-    "bugs": "https://github.com/ihmpavel/expo-video-player/issues",
+    "homepage": "https://github.com/clwy-cn/clwy-expo-video-player",
+    "bugs": "https://github.com/clwy-cn/clwy-expo-video-player/issues",
     "repository": {
         "type": "git"
     },


### PR DESCRIPTION
Allows user to pass controlsStyle props when using the player.

For example:

```js
<VideoPlayer
  // ... others
  controlsStyle={{
    bottom: 24,
    left: 12,
    right: 12,
  }}
/>
```