### PR TITLE
fix: video playing state lost

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -114,7 +114,7 @@ const VideoPlayer = (tempProps) => {
                     ? PlaybackStates.Ended
                     : status.isBuffering
                         ? PlaybackStates.Buffering
-                        : status.shouldPlay
+                        : status.isPlaying || status.shouldPlay
                             ? PlaybackStates.Playing
                             : PlaybackStates.Paused }));
             if ((status.didJustFinish && controlsState === ControlStates.Hidden) ||

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -149,7 +149,7 @@ const VideoPlayer = (tempProps: Props) => {
             ? PlaybackStates.Ended
             : status.isBuffering
             ? PlaybackStates.Buffering
-            : status.shouldPlay
+            : status.isPlaying || status.shouldPlay
             ? PlaybackStates.Playing
             : PlaybackStates.Paused,
       })


### PR DESCRIPTION
Play action works but video can not be paused, on investigating the issue I discovered that the `status.shouldPlay` condition could be the root cause.